### PR TITLE
Fix for 'Machine Learning' header's link in AI.md

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -2,7 +2,7 @@ AI :: Algorithms, Data Mining, Clustering, Data Structures, Machine Learning, Ne
 
 * [CHECKSUM ALGORITHMS](#checksum-algorithms)
 * [DATA STRUCTURES](#data-structures)
-* [MACHINE LEARNING](#machine-learning])
+* [MACHINE LEARNING](#machine-learning)
    * [Clustering Algorithms](#clustering-algorithms)
 * [MARKOV MODELS](#markov-models)
 * [NEURAL NETWORKS](#neural-networks)


### PR DESCRIPTION
Misplaced ']' at end of MACHINE LEARNING link in AI.md removed.
