### PR TITLE
Nonparametric is renamed to KernelEstimator; 

### DIFF
--- a/Statistics.md
+++ b/Statistics.md
@@ -165,7 +165,7 @@
 - [MultivariateAnalysis.jl](https://github.com/lindahua/MultivariateAnalysis.jl) :: A Julia package for multivariate data analysis (e.g. dimension reduction).
 - [NaiveBayes.jl](https://github.com/johnmyleswhite/NaiveBayes.jl) :: The Gaussian Naive Bayes model in Julia.
 - [NaiveBayes.jl](https://github.com/nutsiepully/NaiveBayes.jl) :: Simple Naive Bayes implementation in Julia.
-- [Nonparametric.jl](https://github.com/panlanfeng/Nonparametric.jl) :: The julia package for nonparametric density estimate and regression.
+- [KernelEstimator.jl](https://github.com/panlanfeng/KernelEstimator.jl) :: The julia package for nonparametric density estimate and regression.
 - [NHST.jl](https://github.com/johnmyleswhite/NHST.jl) :: Null hypothesis significance tests.
 - [OpenPP.jl](https://github.com/JuliaStats/OpenPP.jl) :: Open Source Probabilistic Programming in Julia.
 - [ParallelSparseRegression.jl](https://github.com/madeleineudell/ParallelSparseRegression.jl) :: A Julia library for parallel sparse regression, that implements solvers for regression problems including least squares, ridge regression, lasso, non-negative least squares, and elastic net; and proposes to add fast methods to obtain regularization paths.

--- a/X-Platform-SW.md
+++ b/X-Platform-SW.md
@@ -65,7 +65,6 @@
 - [OpenCL.jl](https://github.com/jakebolewski/OpenCL.jl) :: OpenCL bindings for Julia is a cross platform API for programming parallel devices, with implementations from AMD, Nvidia, Intel, and others; similar in scope to PyOpenCL. 
 
 ### Kernel
-- [KernelEstimator.jl](https://github.com/panlanfeng/KernelEstimator.jl) :: The Julia package for various kernel estimation including kernel density estimation, kernel regression and kernel based goodness of fit test.
 
 ### Robots
 - [Arduino.jl](https://github.com/rennis250/Arduino.jl) :: Basic Arduino interface for Julia.


### PR DESCRIPTION
The community thought `Nonparametric` is not descriptive enough. So I renamed the package to be `KernelEstimator`. The robot seems to misunderstand the meaning of `KernelEstimator`. It is not related to hardware...

Lanfeng 
