### PR TITLE
reclassified ConfParser

### DIFF
--- a/Utilities.md
+++ b/Utilities.md
@@ -55,6 +55,7 @@
 + [ExcelReaders.jl](https://github.com/davidanthoff/ExcelReaders.jl) :: A package that provides functionality to read Excel files.
 + [JuliaReport.jl](https://github.com/mpastell/JuliaReport.jl) :: A scientific report generator/literate programming tool for Julia based on Pweave and resembles Knitr and Sweave. JuliaReport relies on the Python package [Pweave](https://github.com/mpastell/Pweave) for document parsing and formatting.
 + [Taro.jl](https://github.com/aviks/Taro.jl) :: can process office documents in Julia.
++ [ConfParser.jl](https://github.com/templarlabs/ConfParser.jl) :: Package for parsing configuration files utilizing ini, http, and simple configuration syntaxes.
 
 ## Document Generator 
 + [Judo.jl](https://github.com/dcjones/Judo.jl) :: is a Julia document generator, which takes documents written in pandoc markdown and converts them into html, but differs from general purpose markdown tools in a few ways.

--- a/Web-Server.md
+++ b/Web-Server.md
@@ -38,7 +38,6 @@ Networking, web security, frameworks and other Web related things go here!
 
 ## Web
 - [Biryani.jl](https://github.com/eraviart/Biryani.jl) :: A conversion and validation toolbox.
-- [ConfParser.jl](https://github.com/templarlabs/ConfParser.jl) :: Package for parsing configuration files utilizing ini, http, and simple configuration syntaxes.
 - [GumboParser.jl](https://github.com/porterjamesj/Gumbo.jl) :: Julia wrapper around google's gumbo library for parsing HTML.
 - [JuliaWebServer](https://github.com/chzyer/JuliaWebServer) :: a webserver for julia.
 - [Laurence.jl](https://github.com/mneudert/Laurence.jl)


### PR DESCRIPTION
svaksha, I came across your Julia.jl repository and noticed that my package, ConfParser, was classified under Web-Server.  I feel that this is inaccurate as multiple services and applications utilize configuration files (not just web servers).  The pull request is my proposed re-classification.  I'd appreciate it if you could accept it. Thank you.