### PR TITLE
add a script to detect broken links

### DIFF
--- a/src/check_broken_links.jl
+++ b/src/check_broken_links.jl
@@ -1,0 +1,40 @@
+## simple check if there are links 404
+
+import Requests: get, statuscode
+
+function scrape_links()
+    _dir = joinpath(Base.source_dir(), "..")
+
+    for file in readdir(_dir)
+        endswith(file, ".md") || continue
+
+        for (i, line) in enumerate(eachline(joinpath(_dir, file)))
+            for m in eachmatch(r"]\((https?://.*?)\)", line)
+                produce((file, i, m[1]))
+            end
+        end
+    end
+end
+
+# `nruning` is the number of concurrent requests, and `nlimit` is it's limit
+cond, nruning, nlimit = Condition(), Ref(0), try parse(Int, ARGS[1]) catch 20 end
+
+for (file, line, link) in Task(scrape_links)
+    nruning[] < nlimit || wait(cond)
+
+    nruning[] += 1
+
+    @schedule try
+        status = get(link) |> statuscode
+        status != 200 && println("In file $file, line: $line, link $link responses $status")
+    catch e
+        println("In file $file, line: $line, request to link $link failed with exception:\n", e)
+    finally
+        nruning[] -= 1
+        notify(cond)
+    end
+end
+
+while nruning[] != 0 wait(cond) end # do not exit before all requests done
+
+println("finished~")


### PR DESCRIPTION
I found many 404 in the packages so I wrote a tiny script to detect them. Here is part of my outputs:

```
In file AI.md, line: 52, link https://github.com/faithlessfriend/Milk.jl responses 404
In file AI.md, line: 72, link https://github.com/EricChiang/YCaret.jl responses 404
In file AI.md, line: 163, link http://matthewrocklin.com/blog/work/2014/01/13/Text-Benchmarks/ responses 404
In file AI.md, line: 109, link https://github.com/denizyuret/KUnet.jl responses 404
In file AI.md, line: 129, request to link https://gist.github.com/kmsquire/7569843 failed with exception:
connect: connection timed out (ETIMEDOUT)
In file AI.md, line: 95, request to link https://github.com/BenConnault/DynamicDiscreteModels.jl failed with exception:
ArgumentError("stream is closed or unusable")
In file AI.md, line: 134, link https://github.com/hshindo/Jukai.jl responses 404
In file Algorithms.md, line: 47, link https://github.com/adlawson/bfs.jl responses 404
In file Algorithms.md, line: 49, link https://github.com/adlawson/dfs.jl responses 404
In file Algorithms.md, line: 50, link https://github.com/MikeInnes/ExpressionMatch.jl responses 404
In file Algorithms.md, line: 98, link http://eschnett.github.io/FlexibleArrays.jl/ responses 404
In file Algorithms.md, line: 141, link http://julialang.org/Graphs.jl/index.html responses 404
In file Algorithms.md, line: 142, link http://beowulf.lcs.mit.edu/18.337/projects/18.337project_huberman_report.pdf responses 404
In file Algorithms.md, line: 114, link https://github.com/andreasnoackjensen/SizeArrays.jl responses 404
In file Algorithms.md, line: 26, link https://github.com/CUHK-MMLAB/SimDistComp.jl responses 404
```

*some of the failing outputs are caused by my poor network ([GFW](https://en.wikipedia.org/wiki/Great_Firewall))

It would be nice if someone can check and remove them regularly.