### PR TITLE
Put AstroLib.jl under JuliaAstro heading

### DIFF
--- a/Space-Science.md
+++ b/Space-Science.md
@@ -15,9 +15,6 @@ __Aeronautics, Astronomy, [Space science](https://en.wikipedia.org/wiki/Outline_
 
 # AstroLibs
 + [Astro.jl](https://github.com/cormullion/Astro.jl) :: Jan Meeus astronomical formulas and some time/date code in Julia.
-+ [AstroLib.jl](https://github.com/JuliaAstro/AstroLib.jl) :: Bundle of small
-  astronomical and astrophysical routines, based on IDL Astronomy User's Library
-  (AstroLib).
 + [Astrodynamics.jl](https://github.com/helgee/Astrodynamics.jl) :: An astrodynamics library in Julia.
 + [CasaCore.jl](https://github.com/mweastwood/CasaCore.jl) :: A Julia wrapper of CasaCore.
 + [Celeste.jl](https://github.com/jeff-regier/Celeste.jl) :: Scalable inference for a generative model of astronomical images. 
@@ -39,6 +36,9 @@ __Aeronautics, Astronomy, [Space science](https://en.wikipedia.org/wiki/Outline_
 ----
 
 # Org-[JuliaAstro](https://JuliaAstro.github.io)
++ [AstroLib.jl](https://github.com/JuliaAstro/AstroLib.jl) :: Bundle of small
+  astronomical and astrophysical routines, based on IDL Astronomy User's Library
+  (AstroLib).
 + [Cosmology.jl](https://github.com/JuliaAstro/Cosmology.jl) :: Cosmology library for Julia.
 + [DustExtinction.jl](https://github.com/JuliaAstro/DustExtinction.jl) :: Models for the interstellar extinction due to dust.
 + [ERFA.jl](https://github.com/JuliaAstro/ERFA.jl) :: Julia wrapper for liberfa.


### PR DESCRIPTION
AstroLib.jl is now part of the JuliaAstro organization. PR to reflect the same