### PR TITLE
Update deprecated UTF8String to String

### DIFF
--- a/src/scrape.jl
+++ b/src/scrape.jl
@@ -8,10 +8,10 @@ function scrape_md(filename)
     category in ("LICENSE", "README") && return []
 
     subcategory = ""
-    records = NTuple{5,UTF8String}[]
+    records = NTuple{5,String}[]
 
     subcategory = ""
-    records = NTuple{5,UTF8String}[]
+    records = NTuple{5,String}[]
 
     # process the  lines
     f = open(filename)


### PR DESCRIPTION
UTF8String is deprecated with julia-0.5 and unknown with julia-0.6

These three commands give the same db.csv file:
    julia-0.5.2 src/scrape.jl # old version
    julia-0.5.2 src/scrape.jl # new version
    julia-0.6.2 src/scrape.jl # new version
