### PR TITLE
[Fixed] a broken hyperlink

### DIFF
--- a/Hardware.md
+++ b/Hardware.md
@@ -101,7 +101,7 @@
 + [TinyG.jl](https://github.com/sjkelly/TinyG.jl) :: This package provides support for CNC controllers running the TinyG firmware, principally developed by Synthetos.
 
 ## [Microcontrollers](https://en.wikipedia.org/wiki/Category:Microcontrollers)
-+ [Arduino.jl](https://github.com/rennis250/Arduino.jl) :: Basic Arduino interface for Julia.
++ [Arduino.jl](https://github.com/ihnorton/Arduino.jl) :: Basic Arduino interface for Julia.
 + [PiGPIO.jl](https://github.com/aviks/PiGPIO.jl) :: Manage external hardware using GPIO pins on the Raspberry Pi.
 
 ----


### PR DESCRIPTION
The previous hyperlink landed a 404 since it was pointing to a deleted repo.