### PR TITLE
Add GrugBot420.jl to AI / Machine Learning section

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -32,6 +32,7 @@
 + [Flimsy.jl](https://github.com/thomlake/Flimsy.jl) :: Gradient based Machine Learning for Julia.
 + [FunctionalDataUtils.jl](https://github.com/rened/FunctionalDataUtils.jl) :: Utility functions for the FunctionalData package, mainly from the area of computer vision / machine learning.
 + [go.jl](https://github.com/dmrd/go.jl) :: A deep learning based Go bot implemented in Julia.
++ [grugbot420](https://github.com/grug-group420/grugbot420) :: A neuromorphic cognitive engine that deploys domain-expert AI specimens through architectural configuration rather than traditional training.
 + [GradientBoost.jl](https://github.com/svs14/GradientBoost.jl) :: Gradient boosting framework for Julia.
 + [Glmnet.jl](https://github.com/simonster/Glmnet.jl) :: Julia wrapper for fitting Lasso/ElasticNet GLM models using glmnet.
 + [HopfieldNets.jl](https://github.com/johnmyleswhite/HopfieldNets.jl) :: Discrete and continuous Hopfield networks in Julia.

--- a/FileIO.md
+++ b/FileIO.md
@@ -66,7 +66,7 @@
 + [XPT.jl](https://github.com/lendle/XPT.jl) :: The XPT package reads SAS® software transport files and converts SAS software datasets to DataFrames.
 
 
-## [Avro](https://en.wikipedia.org/wiki/Apache_Avro]
+## [Avro](https://en.wikipedia.org/wiki/Apache_Avro)
 + [Avro.jl](https://github.com/JuliaData/Avro.jl) ::  Julia implementation of the Apache Avro data standard. It provides convenient APIs for reading/writing data directly in the avro format, or as schema-included object container files.
 
 ## BSON

--- a/Graphics.md
+++ b/Graphics.md
@@ -26,7 +26,7 @@
 
 ----
 
-# (Computer Vision](https://en.wikipedia.org/wiki/Category:Computer_vision)
+# [Computer Vision](https://en.wikipedia.org/wiki/Category:Computer_vision)
 + [AAM.jl](https://github.com/dfdx/AAM.jl) :: Active Appearance Models.
 + [Bezier.jl](https://github.com/dronir/Bezier.jl) :: Julia functions for computing a Bezier curve.
 + [Blending.jl](https://github.com/dejakaymac/Blending.jl).


### PR DESCRIPTION
Adds [GrugBot420.jl](https://github.com/marshalldavidson61-arch/grugbot420) to the Machine Learning section of AI.md.

**GrugBot420.jl** is a neuromorphic cognitive engine written in Julia that models cognition through competing populations of pattern nodes.

Key features:
- Multi-resolution signal scanning (`cheap_scan` → `medium_scan` → `high_res_scan`)
- Subject-specific lobe partitions with O(1) reverse index
- Winner-take-all BrainStem dispatcher with cross-lobe signal propagation
- Dimensional thesaurus for multi-axis semantic similarity
- Visual attention system (EyeSystem) with arousal-gated cutouts
- Hopfield cache for familiar-input fast-path
- Full specimen persistence via gzip-compressed JSON snapshots
- 1,900+ test assertions across 11 test suites

- **License:** MIT
- **Julia compat:** 1.9+
- **GitHub:** https://github.com/marshalldavidson61-arch/grugbot420